### PR TITLE
translate raw engine "node" into "Node.js" for message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 node_js:
   - '4'
   - '6'
+  - '7'
 env:
   global:
     - CXX=g++-4.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+
+## Unreleased
+
+
+### Changed
+
+-   translate raw engine "node" into "Node.js" for message

--- a/__tests__/__snapshots__/engines-error.js.snap
+++ b/__tests__/__snapshots__/engines-error.js.snap
@@ -1,4 +1,4 @@
 exports[`test { node: ">=4" vs "v0.12.0" } 1`] = `
-"my-package requires node >=4 
+"my-package requires Node.js >=4 
 current node version is v0.12.0"
 `;

--- a/__tests__/engines-notify.js
+++ b/__tests__/engines-notify.js
@@ -11,6 +11,7 @@ afterEach(function () {
 // mock console.error
 var oldConsoleError = console.error
 afterEach(function () {
+  // $FlowFixMe: just ignore the mocking here
   console.error = oldConsoleError
 })
 
@@ -23,6 +24,7 @@ var pkg = {
 
 test('{ node: ">=4" vs "v0.12.0" }', function () {
   process.version = 'v0.12.0'
+  // $FlowFixMe: just ignore the mocking here
   console.error = jest.fn()
   var enginesError = enginesNotify({ pkg: pkg })
   expect(console.error).toHaveBeenCalledTimes(1)
@@ -31,6 +33,7 @@ test('{ node: ">=4" vs "v0.12.0" }', function () {
 
 test('{ node: ">=4" vs "v6.9.0" }', function () {
   process.version = 'v6.9.0'
+  // $FlowFixMe: just ignore the mocking here
   console.error = jest.fn()
   var enginesError = enginesNotify({ pkg: pkg })
   expect(console.error).not.toBeCalled()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
-
 build: 'off'
 environment:
   matrix:
     - nodejs_version: '4'
     - nodejs_version: '6'
+    - nodejs_version: '7'
 install:
   - ps: 'Install-Product node $env:nodejs_version x64'
   - npm install

--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@
 
 var util = require('util')
 
+var LABELS = {
+  'node': 'Node.js'
+}
+
 /* ::
 type EnginesErrorData = {
   current: string,
@@ -31,13 +35,14 @@ function EnginesError (data /* : EnginesErrorData */) {
 
 util.inherits(EnginesError, Error)
 
-EnginesError.prototype.toString = function () {
+// $FlowFixMe: ES5-style super() for compatibility with 0.12
+EnginesError.prototype.toString = function () /* : string */ {
   var chalk = require('chalk')
 
   return [
     chalk.blue(this.data.name),
     chalk.reset('requires'),
-    chalk.blue(this.data.engine),
+    chalk.blue(LABELS[this.data.engine] || this.data.engine),
     chalk.green(this.data.required),
     chalk.reset('\ncurrent'),
     chalk.blue(this.data.engine),

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
       "global": {
         "lines": 90
       }
-    }
+    },
+    "testRegex": "/__tests__/[^\\/]*\\.js$"
   },
   "keywords": [
     "engines",
@@ -60,7 +61,7 @@
   "scripts": {
     "eslint": "eslint --fix --cache .",
     "fixpack": "fixpack",
-    "flow_check": "flow check || exit 0",
+    "flow_check": "flow check",
     "jest": "jest",
     "posttest": "npm run eslint && npm run flow_check && npm run fixpack",
     "test": "npm run jest"


### PR DESCRIPTION
### Changed

-   translate raw engine "node" into "Node.js" for message
